### PR TITLE
Don't rely on deprecated save-state and set-output commands

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -35,7 +35,7 @@ runs:
     - name: Get tag
       shell: bash
       id: get_tag
-      run: echo ::set-output name=TAG::$PREFIX_TAG$(echo $GITHUB_REF | cut -d / -f 3)
+      run: echo TAG=$PREFIX_TAG$(echo $GITHUB_REF | cut -d / -f 3) >> $GITHUB_OUTPUT
       env:
         PREFIX_TAG: ${{ inputs.prefix-tag }}
 

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Get tag
       shell: bash
       id: get_tag
-      run: echo ::set-output name=TAG::$PREFIX_TAG$(echo $GITHUB_REF | cut -d / -f 3)
+      run: echo TAG=$PREFIX_TAG$(echo $GITHUB_REF | cut -d / -f 3) >> $GITHUB_OUTPUT
       env:
         PREFIX_TAG: ${{ inputs.prefix-tag }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,8 +47,7 @@ jobs:
 
         -   name: Get Composer Cache Directory
             id: composer-cache
-            run: |
-                echo "::set-output name=dir::$(composer config cache-files-dir)"
+            run: echo dir=$(composer config cache-files-dir) >> $GITHUB_OUTPUT
 
         -   name: Cache Composer Directory
             uses: actions/cache@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,8 +14,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: |
-              echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo dir=$(composer config cache-files-dir) >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
         uses: actions/cache@v2


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Apply https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | PrestaShop Corp
| How to test?      | CI should run as expected
